### PR TITLE
tickets/DM-43162: add ability to revoke only write tokens

### DIFF
--- a/src/lsstvaultutils/_version.py
+++ b/src/lsstvaultutils/_version.py
@@ -1,4 +1,4 @@
 """Version information.
 """
-version_info = (0, 2, 0)
+version_info = (0, 3, 1)
 __version__ = ".".join(map(str, version_info))

--- a/src/lsstvaultutils/tokenadmin.py
+++ b/src/lsstvaultutils/tokenadmin.py
@@ -355,6 +355,8 @@ class AdminTool(object):
             self.vault_client.revoke_token(token=token)
         self.logger.debug("Deleting token store for '%s'." % path)
         dc = RecursiveDeleter(self.url, self.token, self.cacert, self.debug)
+        if self.revoke_write_only:
+            tok_store = f"{tok_store}/write"
         self.logger.debug("Recursive delete of: '%s'" % tok_store)
         dc.recursive_delete(tok_store)
 


### PR DESCRIPTION
As we're migrating off of this and vault.lsst.codes forever...ease the transition by making it easy to revoke only write tokens.